### PR TITLE
[EY Console] Add current_user for start rails console

### DIFF
--- a/lib/engineyard/cli.rb
+++ b/lib/engineyard/cli.rb
@@ -540,7 +540,7 @@ WARNING: Interrupting again may prevent Engine Yard Cloud from recording this
       app_env = fetch_app_environment(options[:app], options[:environment], options[:account])
       instances = filter_servers(app_env.environment, options, default: {app_master: true})
       user = app_env.environment.username
-      cmd = "cd /data/#{app_env.app.name}/current && bundle exec rails console"
+      cmd = "cd /data/#{app_env.app.name}/current && current_user=#{api.current_user.name} bundle exec rails console"
       cmd = Escape.shell_command(['bash','-lc',cmd])
 
       ssh_cmd = ["ssh"]


### PR DESCRIPTION
I have a problem with the **[audited gem](https://github.com/collectiveidea/audited)** in **Rails Console** by `ey console`

- Some case we need to change bad data on Console, and can't logs who changed data
- I viewed code of **audited gem** and I need to get the current user when initializing Rails Console

For example, how to use: `config/initializers/audit.rb` file
```ruby
if defined?(::Rails::Console)
  ::Audited.store[:audited_user] = ENV['current_user']
end
```